### PR TITLE
Build updates and fix iframe RPC

### DIFF
--- a/browser-sdk/index.html
+++ b/browser-sdk/index.html
@@ -12,7 +12,7 @@
       Login
     </button>
     <button
-      onclick="connext.publicIdentifier().then(x => console.log('PUBLIC IDENTIFIER', x))"
+      onclick="console.log('PUBLIC IDENTIFIER', connext.publicIdentifier)"
     >
       Public Identifier
     </button>

--- a/browser-sdk/package-lock.json
+++ b/browser-sdk/package-lock.json
@@ -6445,10 +6445,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.3.tgz",
-      "integrity": "sha512-Mlt39/kL2rA9egcbQbaZV1SNVplGqYYhDDMcGgHPPE0tvM3R4GrB+IEdYy2QtTrdzMQx57ZcqDFf/KWWm8F+uw==",
-      "dev": true,
+      "version": "2.26.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.4.tgz",
+      "integrity": "sha512-6+qsGuP0MXGd7vlYmk72utm1MrgZj5GfXibGL+cRkKQ9+ZL/BnFThDl0D5bcl7AqlzMjAQXRAwZX1HVm22M/4Q==",
       "requires": {
         "fsevents": "~2.1.2"
       }

--- a/browser-sdk/package.json
+++ b/browser-sdk/package.json
@@ -27,7 +27,7 @@
     "@rollup/plugin-replace": "^2.3.3",
     "@types/react": "^16.9.46",
     "@types/react-dom": "^16.9.8",
-    "rollup": "^2.25.0",
+    "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-typescript2": "^0.27.2",
     "serve": "^11.3.2",
     "typescript": "^3.9.7"
@@ -40,6 +40,7 @@
     "magic-sdk": "^2.4.7",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-qr-code": "^1.0.2"
+    "react-qr-code": "^1.0.2",
+    "rollup": "^2.26.4"
   }
 }

--- a/browser-sdk/rollup.config.js
+++ b/browser-sdk/rollup.config.js
@@ -3,20 +3,50 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import replace from "@rollup/plugin-replace";
 import typescript from "rollup-plugin-typescript2";
+import nodePolyfills from 'rollup-plugin-node-polyfills';
 import pkg from "./package.json";
 
 export default {
   input: "./src/index.tsx",
-  output: [{ file: pkg.main, format: "umd", name: "ConnextSDK" }],
+  output: [{
+    file: pkg.main,
+    format: "umd",
+    name: "ConnextSDK",
+    intro: 'var global = window;', // libraries like "eccrypto" assume that "global" is defined as "window", so we need to define that
+  }],
   plugins: [
-    nodeResolve({
-      // preferBuiltins: true,
-      // modulesOnly: true,
-    }), // resolve module names using node_modules and the standard Node module resolution algorithm
-    commonjs(), // compile the module to CommonJS (required in order to support the UMD standard)
-    json(),
-    replace({ "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV) }), // substitute the "NODE_ENV" environment variable for its real value within the compiled output (since environment variables are unavailable in the browser)
+    replace({
+      // substitute the "NODE_ENV" environment variable for its real value within the compiled output
+      // (since environment variables are unavailable in the browser)
+      "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+
+      // the "nuid" library that is part of the NATS project assumes the availability of the "crypto" library built into Node.js
+      // however, the polyfills we're using don't support the randomBytes function, so we'll implement our own shim based on the WebCrypto API
+      'crypto.randomBytes': '(function(l){return window.crypto.getRandomValues(new Uint8Array(l));})',
+
+      // fix some unusual imports in the "memoizee" and "d" NPM modules - they import the "#" module, which is technically an invalid module name - this makes rollup throw an error, where a lazier packer might just let it slide
+      // we'll just re-implement them since they're pretty trivial functions
+      'require("es5-ext/array/#/e-index-of")': `function(searchElement = undefined, fromIndex = undefined) {
+        if (!Number.isNaN(searchElement)) return this.indexOf(searchElement, fromIndex);
+        var newFromIndex = Number.isNaN(fromIndex) ? 0 : fromIndex >= 0 ? Math.floor(fromIndex) : this.length - Math.floor(Math.abs(fromIndex));
+        for (var i = newFromIndex; i < this.length; ++i) {
+          if (this.hasOwnProperty(i) && Number.isNaN(this[i])) return i;
+        }
+        return -1;
+      }`,
+      'require("es5-ext/string/#/contains")': 'function(s, p) { return String.prototype.indexOf.call(this, s, p) > -1; }',
+      delimiters: ['', ''],
+    }),
+    nodeResolve({browser: true, preferBuiltins: false}), // resolve module names using node_modules and the standard Node module resolution algorithm
+    commonjs({requireReturnsDefault: "preferred"}), // compile the module to CommonJS (required in order to support the UMD standard)
+    nodePolyfills(),  // add shims for node.js builtin modules such as "process" and "os"
+    json(),  // support importing JSON files as if they are modules
     typescript(), // compile Typescript to ES5 as per tsconfig.json
+    replace({
+      // the "memoizee" library attempts to perform illegal operations such as modifying modules imported via require() - this causes issues because the generated code tries to prevent this behaviour using Object.freeze
+      // as a hack, we'll disable freezing the object in order to allow this illegal behaviour in "memoizee"
+      'Object.freeze': '(function(x){return x;})',
+    }),
   ],
-  context: "window", // set the value of `this` to `window` at the top-level, Magic Link's SDK depends on that behaviour
+  context: "window", // set the value of `this` to `window` at the top-level - Magic Link's SDK depends on this behaviour
 };

--- a/browser-sdk/src/index.tsx
+++ b/browser-sdk/src/index.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom";
 import EventEmitter from "eventemitter3";
 import { Magic } from "magic-sdk";
-// import { ChannelProvider } from "@connext/channel-provider";
-// import * as connext from "@connext/client";
+import { ChannelProvider } from "@connext/channel-provider";
+import * as connext from "@connext/client";
 
 import Modal from "./components/Modal";
 import {
@@ -20,7 +20,7 @@ import {
 } from "./constants";
 import { IframeRpcConnection, renderElement, SDKError } from "./helpers";
 import { ConnextSDKOptions, ConnextTransaction } from "./typings";
-// import { IConnextClient } from "@connext/types";
+import { IConnextClient } from "@connext/types";
 
 class ConnextSDK extends EventEmitter<string> {
   private modal: Modal | undefined;
@@ -29,7 +29,7 @@ class ConnextSDK extends EventEmitter<string> {
   private network: string;
   private magic: Magic | undefined;
   private pubId: string | undefined;
-  // private channel: IConnextClient | undefined;
+  private channel: IConnextClient | undefined;
 
   constructor(opts?: ConnextSDKOptions) {
     super();
@@ -157,20 +157,19 @@ class ConnextSDK extends EventEmitter<string> {
 
   private async init() {
     if (this.modal) {
-      return;
+      return;  // already initialized
     }
+
+    if (typeof this.iframeRpc === "undefined") {
+      throw new SDKError("Iframe Provider is undefined");
+    }
+
     await this.renderModal();
     await this.waitForIframe();
 
-    // if (typeof this.iframeRpc === "undefined") {
-    //   throw new SDKError("Iframe Provider is undefined");
-    // }
-
-    // this.channel = await connext.connect({
-    //   channelProvider: new ChannelProvider(this.iframeRpc),
-    // });
-
-    // mark this SDK as fully initialized
+    this.channel = await connext.connect({
+      channelProvider: new ChannelProvider(this.iframeRpc),
+    });
   }
 
   private isMagicLoggedIn() {

--- a/iframe-app/src/App.tsx
+++ b/iframe-app/src/App.tsx
@@ -8,6 +8,8 @@ class App extends React.Component {
   private parentOrigin: string | undefined;
 
   async authenticate(signature: string, network = "rinkeby") {
+    // use the entropy of the signature to generate a private key for this wallet
+    // since the signature depends on the private key stored by Magic/Metamask, this is not forgeable by an adversary
     const mnemonic = utils.entropyToMnemonic(utils.keccak256(signature));
     const signer = Wallet.fromMnemonic(mnemonic).privateKey;
     this.channel = await connext.connect(network, { signer });


### PR DESCRIPTION
* Fix iframe RPC issue where DOMContentLoaded fires before the iframe RPC class constructor runs.
* Disallow duplicate subscriptions in iframe RPC.
* Many changes and fixes to allow Magic SDK and @connext/client to coexist within the browser SDK:
    * The `memoizee` library hasn't been updated in 2 years, and does a few bad things:
        * Attempts to modify various `require`'d modules - this is a forbidden operation that works in devmode but results in errors when compiling into a Typescript UMD library - we fixed this by removing safety checks for this particular module.
        * Attempts to import modules containing "#" in their name - this is illegal since module names must be valid identifiers, and `#` is not a valid identifier. To get around this, we use find-and-replace to replace these imports with the short utility functions that they represent.
    * Magic Link's SDK is broken by crypto polyfills, so we can't use `nodePolyfills({crypto: true})`. As a result, the `nuid` library, which depends on `crypto` shims being available, needs to be patched to use WebCrypto. We've implemented a solution to this in the rollup configuration file.
    * The `eccrypto-js` library used by `@connext/utils` checks for `global.crypto` to detect browser WebCrypto. We don't define `global`, so we must inject `crypto` at `global.crypto`.
    * Magic Link's SDK assumes that `this` is `window` at the global level, which isn't true for UMD libraries. We set `this` to `window` at the top-level.